### PR TITLE
Fix handle change lesson and handle next lesson functions to only upd…

### DIFF
--- a/src/app/courses/opioid/page.tsx
+++ b/src/app/courses/opioid/page.tsx
@@ -90,25 +90,25 @@ export default function OpioidHome() {
     if (!progressLoaded) return <div>Loading course...</div>;
 
     const handleChangeLesson = (lessonNumber: number) => {
-        if (
-            lessonNumber > highestReachedLesson &&
-            user &&
-            'course_completion' in user
-        ) {
-            const updatedOpioidCourse = user.course_completion
-                ?.opioidCourse || { courseProgress: 0 };
+        // if (
+        //     lessonNumber > highestReachedLesson &&
+        //     user &&
+        //     'course_completion' in user
+        // ) {
+        //     const updatedOpioidCourse = user.course_completion
+        //         ?.opioidCourse || { courseProgress: 0 };
 
-            useUserStore.getState().setUser({
-                ...user,
-                course_completion: {
-                    ...user.course_completion,
-                    opioidCourse: {
-                        ...updatedOpioidCourse,
-                        courseProgress: (lessonNumber / totalLessons) * 100,
-                    },
-                },
-            });
-        }
+        //     useUserStore.getState().setUser({
+        //         ...user,
+        //         course_completion: {
+        //             ...user.course_completion,
+        //             opioidCourse: {
+        //                 ...updatedOpioidCourse,
+        //                 courseProgress: (lessonNumber / totalLessons) * 100,
+        //             },
+        //         },
+        //     });
+        // }
         setLesson(lessonNumber); // Update the local lesson state
     };
 
@@ -148,23 +148,24 @@ export default function OpioidHome() {
                 const nextIndex = prevIndex + 1;
                 if (nextIndex > highestReachedLesson) {
                     setHighestReachedLesson(nextIndex);
-                }
-                const updatedOpioidCourse = user.course_completion
-                    .opioidCourse || {
-                    courseProgress: 0,
-                };
+                    const updatedOpioidCourse = user.course_completion
+                        .opioidCourse || {
+                        courseProgress: 0,
+                    };
 
-                // Update global state with new course progress
-                useUserStore.getState().setUser({
-                    ...user,
-                    course_completion: {
-                        ...user.course_completion,
-                        opioidCourse: {
-                            ...updatedOpioidCourse,
-                            courseProgress: (nextIndex / totalLessons) * 100,
+                    // Update global state with new course progress
+                    useUserStore.getState().setUser({
+                        ...user,
+                        course_completion: {
+                            ...user.course_completion,
+                            opioidCourse: {
+                                ...updatedOpioidCourse,
+                                courseProgress:
+                                    (nextIndex / totalLessons) * 100,
+                            },
                         },
-                    },
-                });
+                    });
+                }
 
                 return nextIndex;
             });


### PR DESCRIPTION
In opioid/page.tsx (Opioid Course Content)
- Changed HandleChangeLesson to just changing the lesson number (e.g. when clicking on a previously completed lesson just to revisit
- Updated HandleNextLesson to only update global user state course progress if the next lesson is beyond the highest attained course progress

### Summary
Course progress is now fully dynamic to logged in user, correctly updates firebase, and saves/updates/fetches from user state correctly.